### PR TITLE
Add rails:console feature to Capistrano.

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -37,6 +37,7 @@ require "capistrano/nginx"
 require "capistrano/puma"
 require "capistrano/puma/nginx"
 require "capistrano/upload-config"
+require "capistrano/rails/console"
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,8 @@ group :development do
   gem 'capistrano3-puma'
   gem 'capistrano3-nginx'
   gem 'capistrano-upload-config'
+  gem 'capistrano-rails-console', require: false
+
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,9 @@ GEM
     capistrano-rails (1.3.1)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
+    capistrano-rails-console (2.3.0)
+      capistrano (>= 3.5.0, < 4.0.0)
+      sshkit-interactive (~> 0.3.0)
     capistrano-rvm (0.1.2)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
@@ -279,6 +282,8 @@ GEM
     sshkit (1.16.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    sshkit-interactive (0.3.0)
+      sshkit (~> 1.12)
     temple (0.8.0)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
@@ -311,6 +316,7 @@ DEPENDENCIES
   byebug
   capistrano (~> 3.6)
   capistrano-rails (~> 1.1)
+  capistrano-rails-console
   capistrano-rvm
   capistrano-upload-config
   capistrano3-nginx
@@ -339,4 +345,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.15.4
+   1.17.3

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -55,4 +55,3 @@ set :nginx_domains, "www.memorymaestro.com"
 
 # default value: "service nginx”
 set :nginx_service_path, "/etc/init.d/nginx"
-


### PR DESCRIPTION
Adds command: cap production rails:console to access production rails console from local machine.